### PR TITLE
Fix bsconfig package name

### DIFF
--- a/bsconfig.json
+++ b/bsconfig.json
@@ -1,5 +1,5 @@
 {
-  "name": "reason-react-update",
+  "name": "rescript-react-update",
   "reason": {
     "react-jsx": 3
   },


### PR DESCRIPTION
Fixes compiler error when using the package: 
"Error: package name is expected to be rescript-react-update but got reason-react-update"